### PR TITLE
SDK constraint bump to pickup Uri.normalizePath().

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/package_config
 
 environment:
-  sdk: '>=1.0.0 <2.0.0'
+  sdk: '>=1.11.0-dev.0.0 <2.0.0'
 
 dev_dependencies:
   test: '>=0.12.0 <0.13.0'


### PR DESCRIPTION
Fixes SDK constraint to ensure `Uri.normalizePath()` is defined.  

Revision history for `uri.dart` [here](https://code.google.com/p/dart/source/browse/trunk/dart/sdk/lib/core/uri.dart).

@sethladd 
