### PR TITLE
Allow "_" as the first char in a package name

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -11,7 +11,7 @@ import "package:charcode/ascii.dart";
 bool isIdentifier(String string) {
   if (string.isEmpty) return false;
   int firstChar = string.codeUnitAt(0);
-  int firstCharLower = firstChar |= 0x20;
+  int firstCharLower = firstChar | 0x20;
   if (firstCharLower < $a || firstCharLower > $z) {
     if (firstChar != $_ && firstChar != $$) return false;
   }

--- a/test/discovery_test.dart
+++ b/test/discovery_test.dart
@@ -93,6 +93,14 @@ main() {
     validatePackagesDir(resolver, location);
   });
 
+  generalTest("underscore packages",
+              {"packages": {"_foo": {}}},
+              (Uri location) async {
+    Packages resolver = await findPackages(location);
+    expect(resolver.resolve(pkg("_foo", "foo.dart")),
+           equals(location.resolve("packages/_foo/foo.dart")));
+  });
+
   fileTest(".packages recursive",
            {".packages": packagesFile, "subdir": {"script.dart": "main(){}"}},
            (Uri location) async {


### PR DESCRIPTION
Fixes dart-lang/tools#1506 
@pq @sethladd 
