### PR TITLE
Remove space that causes link not to render on pub.dartlang.org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Support for working with **Package Resolution Configuration** files as described 
 in this [DEP](https://github.com/lrhn/dep-pkgspec/blob/master/DEP-pkgspec.md), 
-under review [here] (https://github.com/dart-lang/dart_enhancement_proposals/issues/5).
+under review [here](https://github.com/dart-lang/dart_enhancement_proposals/issues/5).
 
 [![Build Status](https://travis-ci.org/dart-lang/package_config.svg?branch=master)](https://travis-ci.org/dart-lang/package_config) [![pub package](https://img.shields.io/pub/v/package_config.svg)](https://pub.dartlang.org/packages/package_config) 
 


### PR DESCRIPTION
The link doesn't render correctly here because of the space:

https://pub.dartlang.org/packages/package_config
