### PR TITLE
Add support for writing defaultPackageName and fragment in .packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.0
+ - Added support for writing default-package entries.
+
 ## 1.1.0
 
 - Allow parsing files with default-package entries and metadata.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: package_config
-version: 1.1.0
+version: 1.2.0
 description: Support for working with Package Resolution config files.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/package_config

--- a/test/parse_write_test.dart
+++ b/test/parse_write_test.dart
@@ -4,6 +4,7 @@
 
 library package_config.parse_write_test;
 
+import "dart:convert" show utf8;
 import "package:package_config/packages_file.dart";
 import "package:test/test.dart";
 
@@ -31,6 +32,40 @@ main() {
             var content = writeToString(map, baseUri: packagesFile).codeUnits;
             var resultMap = parse(content, packagesFile);
             expect(resultMap, map);
+          });
+
+          test("write with defaultPackageName", () {
+            var content = writeToString(
+              {'': Uri.parse('my_pkg')}..addAll(map),
+              allowDefaultPackage: true,
+            ).codeUnits;
+            var resultMap = parse(
+              content,
+              packagesFile,
+              allowDefaultPackage: true,
+            );
+            expect(resultMap[''].toString(), 'my_pkg');
+            expect(
+              resultMap,
+              {'': Uri.parse('my_pkg')}..addAll(map),
+            );
+          });
+
+          test("write with defaultPackageName (utf8)", () {
+            var content = utf8.encode(writeToString(
+              {'': Uri.parse('my_pkg')}..addAll(map),
+              allowDefaultPackage: true,
+            ));
+            var resultMap = parse(
+              content,
+              packagesFile,
+              allowDefaultPackage: true,
+            );
+            expect(resultMap[''].toString(), 'my_pkg');
+            expect(
+              resultMap,
+              {'': Uri.parse('my_pkg')}..addAll(map),
+            );
           });
         });
       }
@@ -82,8 +117,16 @@ main() {
   });
 }
 
-String writeToString(Map<String, Uri> map, {Uri baseUri, String comment}) {
+String writeToString(
+  Map<String, Uri> map, {
+  Uri baseUri,
+  String comment,
+  bool allowDefaultPackage = false,
+}) {
   var buffer = new StringBuffer();
-  write(buffer, map, baseUri: baseUri, comment: comment);
+  write(buffer, map,
+      baseUri: baseUri,
+      comment: comment,
+      allowDefaultPackage: allowDefaultPackage);
   return buffer.toString();
 }


### PR DESCRIPTION
 * Added support for writing a `defaultPackageName`.
 * Fixed bug when `Uri` included a fragment.
 * More tests (added utf8 test cases).