### PR TITLE
Fix trailing slash logic when writing .packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.2.0
  - Added support for writing default-package entries.
+ - Fixed bug when writing `Uri`s containing a fragment.
 
 ## 1.1.0
 

--- a/lib/packages_file.dart
+++ b/lib/packages_file.dart
@@ -162,10 +162,10 @@ void write(StringSink output, Map<String, Uri> packageMapping,
     if (baseUri != null) {
       uri = _relativize(uri, baseUri);
     }
-    output.write(uri);
     if (!uri.path.endsWith('/')) {
-      output.write('/');
+      uri = uri.replace(path: uri.path + '/');
     }
+    output.write(uri);
     output.writeln();
   });
 }


### PR DESCRIPTION
This was originally in https://github.com/dart-lang/package_config/pull/53, but I accidentally squashed it away updating my PR :see_no_evil: 