### PR TITLE
Don't depend on package pedantic version later than minimum requirement.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,7 +2,7 @@
 # for details. All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-include: package:pedantic/analysis_options.1.9.0.yaml
+include: package:pedantic/analysis_options.1.8.0.yaml
 analyzer:
   errors:
     annotate_overrides: ignore


### PR DESCRIPTION
The pubspec.yaml requirement is `^1.8.0`, so don't use 1.9.0.