### PR TITLE
Make `.packages` files be more clever about defaults.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Updated to support new rules for picking `package_config.json` over
   a specified `.packages`.
+- Deduce package root from `.packages` derived package configuration,
+  and default all such packages to language version 2.7.
 
 ## 1.9.1
 

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -36,7 +36,7 @@ void main() {
       expect(foo, isNotNull);
       expect(foo.root, Uri.parse("file:///foo/"));
       expect(foo.packageUriRoot, Uri.parse("file:///foo/lib/"));
-      expect(foo.languageVersion, null);
+      expect(foo.languageVersion, LanguageVersion(2, 7));
     });
 
     test("valid empty", () {

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -34,7 +34,7 @@ void main() {
 
       var foo = result["foo"];
       expect(foo, isNotNull);
-      expect(foo.root, Uri.parse("file:///foo/lib/"));
+      expect(foo.root, Uri.parse("file:///foo/"));
       expect(foo.packageUriRoot, Uri.parse("file:///foo/lib/"));
       expect(foo.languageVersion, null);
     });


### PR DESCRIPTION
The `PackageConfig` for a `.packages` file now assigns a default language version of 2.7
to all packages, and if the package location ends in `/lib/`, it assumes the package's
root directory is the parent directory of that.