### PR TITLE
fix a lint about an unused import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dart:
 dart_task:
   - test
   - dartfmt
-  - dartanalyzer: --fatal-warnings .
+  - dartanalyzer: --fatal-warnings --fatal-infos .
 
 matrix:
   include:

--- a/lib/src/package_config_io.dart
+++ b/lib/src/package_config_io.dart
@@ -8,7 +8,6 @@ import "dart:convert";
 import "dart:io";
 import "dart:typed_data";
 
-import "discovery.dart" show packageConfigJsonPath;
 import "errors.dart";
 import "package_config_impl.dart";
 import "package_config_json.dart";


### PR DESCRIPTION
- fix a lint about an unused import
- turn on `--fatal-infos` for travis

cc @pq @kevmoo @lrhn 