### PR TITLE
[WIP] add generate_from_legacy binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.10.0
+
+- Adds a `generate_from_legacy` script which generates a new style package
+  config from an old style `.packages` file, reading the corresponding pubspec
+  files in order to get the correct language versions. 
+
 ## 1.9.3
 
 - Fix `Package` constructor not accepting relative `packageUriRoot`.

--- a/bin/generate_from_legacy.dart
+++ b/bin/generate_from_legacy.dart
@@ -46,8 +46,6 @@ void main(List<String> args) async {
       pubspec = packageRoot.resolve('pubspec.yaml');
       languageVersion = await languageVersionFromPubspec(pubspec, name);
     }
-    print(packageRoot);
-    print(uri);
     packages.add(Package(name, packageRoot,
         languageVersion: languageVersion, packageUriRoot: uri));
   }

--- a/bin/generate_from_legacy.dart
+++ b/bin/generate_from_legacy.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:package_config/package_config.dart';
+import 'package:package_config/packages_file.dart'; // ignore: deprecated_member_use_from_same_package
+import 'package:package_config/src/package_config_json.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:yaml/yaml.dart';
+
+void main(List<String> args) async {
+  if (args.length != 1) {
+    throw ArgumentError('Unexpected arguments $args\n\n$usage');
+  }
+  if (args.first == 'help') {
+    print(usage);
+    return;
+  }
+  var packagesUri = Uri.base.resolve(args.first);
+  var packagesFile = File.fromUri(packagesUri);
+  if (!await packagesFile.exists()) {
+    throw ArgumentError('Unable to read file at `$packagesUri`');
+  }
+  var packageMap = parse(await packagesFile.readAsBytes(), packagesFile.uri);
+  print('Successfully read $packagesUri, now generating package config');
+
+  var packages = <Package>[];
+  for (var packageEntry in packageMap.entries) {
+    var name = packageEntry.key;
+    var uri = packageEntry.value;
+    if (uri.scheme != 'file') {
+      throw ArgumentError(
+          'Only file: schemes are supported, but the `$name` package has '
+          'the following uri: ${uri}');
+    }
+    Uri packageRoot;
+    Uri pubspec;
+    LanguageVersion languageVersion;
+    // Pub packages will always have a path ending in `lib/`, and a pubspec
+    // directly above that.
+    if (uri.path.endsWith('lib/')) {
+      packageRoot = uri.resolve('../');
+      pubspec = packageRoot.resolve('pubspec.yaml');
+      languageVersion = await languageVersionFromPubspec(pubspec, name);
+    }
+    print(packageRoot);
+    print(uri);
+    packages.add(Package(name, packageRoot,
+        languageVersion: languageVersion, packageUriRoot: uri));
+  }
+  var outputFile =
+      File.fromUri(packagesFile.uri.resolve('.dart_tool/package_config.json'));
+  print('Writing output to ${outputFile.uri}');
+  var baseUri = outputFile.uri;
+  var sink = outputFile.openWrite(encoding: utf8);
+  writePackageConfigJsonUtf8(PackageConfig(packages), baseUri, sink);
+  await sink.close();
+  print('Done!');
+}
+
+const usage = 'Usage: pub run package_config:generate_from_legacy <input-file>';
+
+Future<LanguageVersion> languageVersionFromPubspec(
+    Uri pubspec, String packageName) async {
+  var pubspecFile = File.fromUri(pubspec);
+  if (!await pubspecFile.exists()) {
+    throw ArgumentError(
+        'Cannot read a pubspec.yaml for package $packageName at '
+        '${pubspecFile.path}');
+  }
+  var pubspecYaml =
+      loadYaml(await pubspecFile.readAsString(), sourceUrl: pubspec) as YamlMap;
+
+  // Find the sdk constraint, or return null if none is present
+  var environment = pubspecYaml['environment'] as YamlMap;
+  if (environment == null) return null;
+  var sdkConstraint = environment['version'] as String;
+  if (sdkConstraint == null) return null;
+
+  var parsedConstraint = VersionConstraint.parse(sdkConstraint);
+  var min = parsedConstraint is Version
+      ? parsedConstraint
+      : parsedConstraint is VersionRange
+          ? parsedConstraint.min
+          : throw 'Unsupported version constraint type $parsedConstraint';
+  return LanguageVersion(min.major, min.minor);
+}

--- a/bin/generate_from_legacy.dart
+++ b/bin/generate_from_legacy.dart
@@ -75,7 +75,7 @@ Future<LanguageVersion> languageVersionFromPubspec(
   // Find the sdk constraint, or return null if none is present
   var environment = pubspecYaml['environment'] as YamlMap;
   if (environment == null) return null;
-  var sdkConstraint = environment['version'] as String;
+  var sdkConstraint = environment['sdk'] as String;
   if (sdkConstraint == null) return null;
 
   var parsedConstraint = VersionConstraint.parse(sdkConstraint);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: package_config
-version: 1.9.3
+version: 1.10.0
 description: Support for working with Package Configuration files.
 homepage: https://github.com/dart-lang/package_config
 
@@ -9,6 +9,8 @@ environment:
 dependencies:
   path: ^1.6.4
   charcode: ^1.1.0
+  yaml: any
+  pub_semver: any
 
 dev_dependencies:
   test: ^1.6.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   path: ^1.6.4
   charcode: ^1.1.0
-  yaml: any
-  pub_semver: any
+  yaml: ^2.2.0
+  pub_semver: ^1.4.3
 
 dev_dependencies:
   test: ^1.6.4


### PR DESCRIPTION
Would resolve https://github.com/dart-lang/tools/issues/1535, runnable with `pub global activate package_config && pub global run package_config:generate_from_legacy`.

However, I think that adding the extra dependencies here is not ideal. I don't believe these can be dev dependencies if they are required by a pub runnable script.

We could just keep a copy of this script in flutter for use there, or create a whole new package, cc @jonahwilliams

Note that if we copy the script we would want to be able to remove the src imports and deprecated imports.

Either way the existence of this script would be motivation to not deprecate parsing of the old format. 