### PR TITLE
Remove unused async import

### DIFF
--- a/lib/discovery.dart
+++ b/lib/discovery.dart
@@ -5,7 +5,6 @@
 @Deprecated("Use the package_config.json based API")
 library package_config.discovery;
 
-import "dart:async";
 import "dart:io";
 import "dart:typed_data" show Uint8List;
 


### PR DESCRIPTION
Since this version doesn't support Dart 2.0, this import is unnecessary.