### PR TITLE
Add override for _fe_analyzer_shared

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,10 @@ dev_dependencies:
   test: ^1.16.0-nullsafety.4
 
 dependency_overrides:
+  _fe_analyzer_shared:
+    git:
+      url: git://github.com/dart-lang/sdk.git
+      path: pkg/_fe_analyzer_shared
   analyzer:
     git:
       url: git://github.com/dart-lang/sdk.git


### PR DESCRIPTION
We currently need the dependency overrides because of the circular
dev_dependencies and the major version change. It is still safe to
publish since no normal dependencies are overridden.

The dependency overrides are causing us to pull in incompatible versions
of `analyzer` and `_fe_analyzer_shared` since there was a breaking
change in the latter. Pulling it in from the SDK should cause both to be
compatible until we can drop the overrides entirely.