### PR TITLE
migrate to `dart analyze`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dart:
 dart_task:
   - test
   - dartfmt
-  - dartanalyzer: --fatal-warnings --fatal-infos .
+  - dart analyze --fatal-infos .
 
 matrix:
   include:


### PR DESCRIPTION
(warnings are now fatal by default)

/cc @natebosch @lrhn 