### PR TITLE
Make it possible to control whether the `rootUri` path is relativized.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Migrate to null safety.
 - Remove legacy APIs.
+- Adds `relativeRoot` property to `Package` which controls whether to
+  make the root URI relative when writing a configuration file.
 
 ## 1.9.3
 

--- a/lib/src/package_config.dart
+++ b/lib/src/package_config.dart
@@ -224,14 +224,20 @@ abstract class Package {
   /// version, which means two decimal integer literals separated by a `.`,
   /// where the integer literals have no leading zeros unless they are
   /// a single zero digit.
+  ///
+  /// The [relativeRoot] controls whether the [root] is written as
+  /// relative to the `package_config.json` file when the package
+  /// configuration is written to a file. It defaults to being relative.
+  ///
   /// If [extraData] is supplied, it will be available as the
   /// [Package.extraData] of the created package.
   factory Package(String name, Uri root,
           {Uri? packageUriRoot,
           LanguageVersion? languageVersion,
-          Object? extraData}) =>
-      SimplePackage.validate(
-          name, root, packageUriRoot, languageVersion, extraData, throwError)!;
+          Object? extraData,
+          bool relativeRoot = true}) =>
+      SimplePackage.validate(name, root, packageUriRoot, languageVersion,
+          extraData, relativeRoot, throwError)!;
 
   /// The package-name of the package.
   String get name;
@@ -275,6 +281,13 @@ abstract class Package {
   /// The standard `package_config.json` file storage will only store
   /// JSON-like list/map data structures.
   Object? get extraData;
+
+  /// Whether the [root] URI should be written as relative.
+  ///
+  /// When the configuration is written to a `package_config.json`
+  /// file, the [root] URI can be either relative to the file
+  /// location or absolute, controller by this value.
+  bool get relativeRoot;
 }
 
 /// A language version.

--- a/lib/src/package_config_impl.dart
+++ b/lib/src/package_config_impl.dart
@@ -61,7 +61,8 @@ class SimplePackageConfig implements PackageConfig {
             originalPackage.root,
             originalPackage.packageUriRoot,
             originalPackage.languageVersion,
-            originalPackage.extraData, (error) {
+            originalPackage.extraData,
+            originalPackage.relativeRoot, (error) {
           if (error is PackageConfigArgumentError) {
             onError(PackageConfigArgumentError(packages, "packages",
                 "Package ${package!.name}: ${error.message}"));
@@ -159,9 +160,10 @@ class SimplePackage implements Package {
   final Uri packageUriRoot;
   final LanguageVersion? languageVersion;
   final Object? extraData;
+  final bool relativeRoot;
 
   SimplePackage._(this.name, this.root, this.packageUriRoot,
-      this.languageVersion, this.extraData);
+      this.languageVersion, this.extraData, this.relativeRoot);
 
   /// Creates a [SimplePackage] with the provided content.
   ///
@@ -184,6 +186,7 @@ class SimplePackage implements Package {
       Uri? packageUriRoot,
       LanguageVersion? languageVersion,
       Object? extraData,
+      bool relativeRoot,
       void onError(Object error)) {
     var fatalError = false;
     var invalidIndex = checkPackageName(name);
@@ -229,7 +232,7 @@ class SimplePackage implements Package {
     }
     if (fatalError) return null;
     return SimplePackage._(
-        name, root, packageUriRoot, languageVersion, extraData);
+        name, root, packageUriRoot, languageVersion, extraData, relativeRoot);
   }
 }
 

--- a/lib/src/packages_file.dart
+++ b/lib/src/packages_file.dart
@@ -96,11 +96,13 @@ PackageConfig parse(
     var packageValue = String.fromCharCodes(source, separatorIndex + 1, end);
     Uri packageLocation;
     try {
-      packageLocation = baseLocation.resolve(packageValue);
+      packageLocation = Uri.parse(packageValue);
     } on FormatException catch (e) {
       onError(PackageConfigFormatException.from(e));
       continue;
     }
+    var relativeRoot = !hasAbsolutePath(packageLocation);
+    packageLocation = baseLocation.resolveUri(packageLocation);
     if (packageLocation.isScheme("package")) {
       onError(PackageConfigFormatException(
           "Package URI as location for package", source, separatorIndex + 1));
@@ -122,8 +124,8 @@ PackageConfig parse(
       rootUri =
           packageLocation.replace(path: path.substring(0, path.length - 4));
     }
-    var package = SimplePackage.validate(
-        packageName, rootUri, packageLocation, _languageVersion, null, (error) {
+    var package = SimplePackage.validate(packageName, rootUri, packageLocation,
+        _languageVersion, null, relativeRoot, (error) {
       if (error is ArgumentError) {
         onError(PackageConfigFormatException(error.message, source));
       } else {

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -137,6 +137,21 @@ int firstNonWhitespaceChar(List<int> bytes) {
   return -1;
 }
 
+/// Appends a trailing `/` if the path doesn't end with one.
+String trailingSlash(String path) {
+  if (path.isEmpty || path.endsWith("/")) return path;
+  return path + "/";
+}
+
+/// Whether a URI should not be considered relative to the base URI.
+///
+/// Used to determine whether a parsed root URI is relative
+/// to the configuration file or not.
+/// If it is relative, then it's rewritten as relative when
+/// output again later. If not, it's output as absolute.
+bool hasAbsolutePath(Uri uri) =>
+    uri.hasScheme || uri.hasAuthority || uri.hasAbsolutePath;
+
 /// Attempts to return a relative path-only URI for [uri].
 ///
 /// First removes any query or fragment part from [uri].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: package_config
-version: 2.0.0-nullsafety.0
+version: 2.0.0-nullsafety.1
 description: Support for working with Package Configuration files.
 homepage: https://github.com/dart-lang/package_config
 

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -37,6 +37,7 @@ void main() {
       expect(foo.root, Uri.parse("file:///foo/"));
       expect(foo.packageUriRoot, Uri.parse("file:///foo/lib/"));
       expect(foo.languageVersion, LanguageVersion(2, 7));
+      expect(foo.relativeRoot, false);
     });
 
     test("valid empty", () {
@@ -132,6 +133,7 @@ void main() {
       expect(foo.packageUriRoot, Uri.parse("file:///foo/lib/"));
       expect(foo.languageVersion, LanguageVersion(2, 5));
       expect(foo.extraData, {"nonstandard": true});
+      expect(foo.relativeRoot, false);
 
       var bar = config["bar"]!;
       expect(bar, isNotNull);
@@ -139,12 +141,14 @@ void main() {
       expect(bar.packageUriRoot, Uri.parse("file:///bar/lib/"));
       expect(bar.languageVersion, LanguageVersion(9999, 9999));
       expect(bar.extraData, null);
+      expect(bar.relativeRoot, false);
 
       var baz = config["baz"]!;
       expect(baz, isNotNull);
       expect(baz.root, Uri.parse("file:///tmp/"));
       expect(baz.packageUriRoot, Uri.parse("file:///tmp/lib/"));
       expect(baz.languageVersion, null);
+      expect(baz.relativeRoot, true);
 
       // No slash after root or package root. One is inserted.
       var noslash = config["noslash"]!;
@@ -152,6 +156,7 @@ void main() {
       expect(noslash.root, Uri.parse("file:///tmp/noslash/"));
       expect(noslash.packageUriRoot, Uri.parse("file:///tmp/noslash/lib/"));
       expect(noslash.languageVersion, null);
+      expect(noslash.relativeRoot, true);
 
       expect(config.extraData, {
         "generator": "pub",


### PR DESCRIPTION
Adds `relativeRoot` boolean to `PackageConfig` which does nothing
except to control whether the `root` URI is made relative to the
configuration file when written to a configuration file.

The parsers remember whether the root URI was relative originally.

Also fixes bad cast.

Fixes dart-lang/tools#1538