### PR TITLE
Use unique library names

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [dev]
+        sdk: [2.12.0, dev]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Use unique library names to correct docs issue.
+
 ## 2.0.0
 
 - Migrate to null safety.

--- a/lib/package_config_types.dart
+++ b/lib/package_config_types.dart
@@ -4,7 +4,7 @@
 
 /// A package configuration is a way to assign file paths to package URIs,
 /// and vice-versa,
-library package_config.package_config;
+library package_config.package_config_types;
 
 export "src/package_config.dart"
     show PackageConfig, Package, LanguageVersion, InvalidLanguageVersion;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: package_config
-version: 2.0.0
+version: 2.0.1
 description: Support for working with Package Configuration files.
 homepage: https://github.com/dart-lang/package_config
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   path: ^1.8.0
@@ -13,11 +13,5 @@ dev_dependencies:
   build_runner: ^1.10.0
   build_test: ^1.3.0
   build_web_compilers: ^2.12.2
-  pedantic: ^1.10.0-nullsafety.0
-  test: ^1.16.0-nullsafety.19
-
-# Required due to dependency cycles
-dependency_overrides:
-  test: ^1.16.0-nullsafety.19
-  coverage: ^0.15.1
-  analyzer: ^0.41.0
+  pedantic: ^1.10.0
+  test: ^1.16.0


### PR DESCRIPTION
The current dartdocs output does not link correctly because of the
conflicting library names.

- Use a stable SDK and dependencies.
- Test on the oldest supported SDK.
- Remove dependency overrides.