### PR TITLE
Fix typo: "packjage_config"

### DIFF
--- a/lib/src/package_config.dart
+++ b/lib/src/package_config.dart
@@ -204,7 +204,7 @@ abstract class PackageConfig {
   /// Extra data associated with the package configuration.
   ///
   /// The data may be in any format, depending on who introduced it.
-  /// The standard `packjage_config.json` file storage will only store
+  /// The standard `package_config.json` file storage will only store
   /// JSON-like list/map data structures.
   Object? get extraData;
 }


### PR DESCRIPTION
Fixes a typo in a dartdoc comment.