### PR TITLE
Ignore unnecessary casts from utf8.encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.2-dev
+
 ## 2.0.1
 
 - Use unique library names to correct docs issue.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: package_config
-version: 2.0.1
+version: 2.0.2-dev
 description: Support for working with Package Configuration files.
 homepage: https://github.com/dart-lang/package_config
 

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -113,6 +113,7 @@ void main() {
         }
         ''';
       var config = parsePackageConfigBytes(
+          // ignore: unnecessary_cast
           utf8.encode(packageConfigFile) as Uint8List,
           Uri.parse('file:///tmp/.dart_tool/file.dart'),
           throwError);
@@ -193,6 +194,7 @@ void main() {
         }
         ''';
       var config = parsePackageConfigBytes(
+          // ignore: unnecessary_cast
           utf8.encode(packageConfigFile) as Uint8List,
           Uri.parse('file:///tmp/.dart_tool/file.dart'),
           throwError);
@@ -219,6 +221,7 @@ void main() {
     var root = '"rootUri":"/foo/"';
     test('minimal', () {
       var config = parsePackageConfigBytes(
+          // ignore: unnecessary_cast
           utf8.encode('{$cfg,$pkgs}') as Uint8List,
           Uri.parse('file:///tmp/.dart_tool/file.dart'),
           throwError);
@@ -229,6 +232,7 @@ void main() {
       // A package must have a name and a rootUri, the remaining properties
       // are optional.
       var config = parsePackageConfigBytes(
+          // ignore: unnecessary_cast
           utf8.encode('{$cfg,"packages":[{$name,$root}]}') as Uint8List,
           Uri.parse('file:///tmp/.dart_tool/file.dart'),
           throwError);
@@ -246,6 +250,7 @@ void main() {
           {'name': 'qux', 'rootUri': '/foo/qux/', 'packageUri': 'lib/'},
         ]
       }));
+      // ignore: unnecessary_cast
       var config = parsePackageConfigBytes(configBytes as Uint8List,
           Uri.parse('file:///tmp/.dart_tool/file.dart'), throwError);
       expect(config.version, 2);
@@ -271,6 +276,7 @@ void main() {
       void testThrows(String name, String source) {
         test(name, () {
           expect(
+              // ignore: unnecessary_cast
               () => parsePackageConfigBytes(utf8.encode(source) as Uint8List,
                   Uri.parse('file:///tmp/.dart_tool/file.dart'), throwError),
               throwsA(TypeMatcher<FormatException>()));

--- a/test/src/util.dart
+++ b/test/src/util.dart
@@ -48,6 +48,7 @@ void loaderTest(
       if (value is! Map<String, Object?>) return null;
       value = value[parts[i]];
     }
+    // ignore: unnecessary_cast
     if (value is String) return utf8.encode(value) as Uint8List;
     return null;
   }


### PR DESCRIPTION
An upcoming SDK change will change the return type to `Uint8List` which
makes the casts unnecessary and introduces analyzer diagnostics.
Preemptively ignore these to make it easier to roll the SDK.

https://dart-review.googlesource.com/c/sdk/+/208190