### PR TITLE
Preemptively bump to a -dev version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.3-dev
+
 ## 2.0.2
 
 - Update package description and README.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: package_config
-version: 2.0.2
+version: 2.0.3-dev
 description: Support for reading and writing Dart Package Configuration files.
 homepage: https://github.com/dart-lang/package_config
 


### PR DESCRIPTION
The code in the repo has diverged from what was published in `2.0.2` so
we don't want the pubspec to still have that version. There are no user
facing changes.