### PR TITLE
Fix broken link for language-versioning spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![pub package](https://img.shields.io/pub/v/package_config.svg)](https://pub.dev/packages/package_config)
 
 Support for working with **Package Configuration** files as described
-in the Package Configuration v2 [design document](https://github.com/dart-lang/language/blob/master/accepted/future-releases/language-versioning/package-config-file-v2.md).
+in the Package Configuration v2 [design document](https://github.com/dart-lang/language/blob/master/accepted/2.8/language-versioning/package-config-file-v2.md).
 
 A Dart package configuration file is used to resolve Dart package names (e.g.
 `foobar`) to Dart files containing the source code for that package (e.g.


### PR DESCRIPTION
Would be nice if language specifications / proposals had a permalink, we reference these from all sorts of places.

It's possible to create `dart.dev/go/...` links [here](https://github.com/dart-lang/site-www/blob/ba4d043d8eea4d4bb5cdf688d9587337371a9a3d/firebase.json#L137-L156), but it's probably too much of hassle to update those :D