### PR TITLE
add test validating current behavior of packageOf, run CI on windows

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -45,8 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Add macos-latest and/or windows-latest if relevant for this package.
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         sdk: [2.18.0, dev]
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -55,6 +55,9 @@ jobs:
       - id: install
         name: Install dependencies
         run: dart pub get
-      - name: Run tests
-        run: dart run build_runner test -- -p chrome,vm
+      - name: Run web tests
+        run: dart run build_runner test -- -p chrome
+        if: always() && steps.install.outcome == 'success'
+      - name: Run vm tests
+        run: dart test
         if: always() && steps.install.outcome == 'success'

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -55,9 +55,6 @@ jobs:
       - id: install
         name: Install dependencies
         run: dart pub get
-      - name: Run web tests
-        run: dart run build_runner test -- -p chrome
-        if: always() && steps.install.outcome == 'success'
-      - name: Run vm tests
-        run: dart test
+      - name: Run tests
+        run: dart test -p chrome,vm
         if: always() && steps.install.outcome == 'success'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,16 +10,5 @@ dependencies:
   path: ^1.8.0
 
 dev_dependencies:
-  build_runner: ^2.0.0
-  build_test: ^2.1.2
-  build_web_compilers: ^4.0.0
   dart_flutter_team_lints: ^2.0.0
   test: ^1.16.0
-
-# TODO: Remove once the fix for precompiled mode is published.
-dependency_overrides:
-  test:
-    git:
-      url: https://github.com/dart-lang/test.git
-      ref: master
-      path: pkgs/test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,3 +15,11 @@ dev_dependencies:
   build_web_compilers: ^4.0.0
   dart_flutter_team_lints: ^2.0.0
   test: ^1.16.0
+
+# TODO: Remove once the fix for precompiled mode is published.
+dependency_overrides:
+  test:
+    git:
+      url: https://github.com/dart-lang/test.git
+      ref: master
+      path: pkgs/test

--- a/test/discovery_test.dart
+++ b/test/discovery_test.dart
@@ -59,7 +59,7 @@ void main() {
     fileTest('package_config.json', {
       '.packages': 'invalid .packages file',
       'script.dart': 'main(){}',
-      'packages': {'shouldNotBeFound': <Never>{}},
+      'packages': {'shouldNotBeFound': <Never, Never>{}},
       '.dart_tool': {
         'package_config.json': packageConfigFile,
       }

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -308,8 +308,11 @@ void main() {
           {'name': 'foo', 'rootUri': 'file:///C:/Foo/', 'packageUri': 'lib/'},
         ]
       }));
-      var config = parsePackageConfigBytes(configBytes as Uint8List,
-          Uri.parse('file:///C:/tmp/.dart_tool/file.dart'), throwError);
+      var config = parsePackageConfigBytes(
+          // ignore: unnecessary_cast
+          configBytes as Uint8List,
+          Uri.parse('file:///C:/tmp/.dart_tool/file.dart'),
+          throwError);
       expect(config.version, 2);
       expect(
           config.packageOf(Uri.parse('file:///C:/foo/lala/lala.dart')), null);

--- a/test/parse_test.dart
+++ b/test/parse_test.dart
@@ -302,6 +302,22 @@ void main() {
           Uri.parse('package:qux/diz'));
     });
 
+    test('packageOf is case sensitive on windows', () {
+      var configBytes = utf8.encode(json.encode({
+        'configVersion': 2,
+        'packages': [
+          {'name': 'foo', 'rootUri': 'file:///C:/Foo/', 'packageUri': 'lib/'},
+        ]
+      }));
+      var config = parsePackageConfigBytes(configBytes as Uint8List,
+          Uri.parse('file:///C:/tmp/.dart_tool/file.dart'), throwError);
+      expect(config.version, 2);
+      expect(
+          config.packageOf(Uri.parse('file:///C:/foo/lala/lala.dart')), null);
+      expect(config.packageOf(Uri.parse('file:///C:/Foo/lala/lala.dart'))!.name,
+          'foo');
+    });
+
     group('invalid', () {
       void testThrows(String name, String source) {
         test(name, () {


### PR DESCRIPTION
- validates the behavior of https://github.com/dart-lang/tools/issues/1545 today (but does not change it)
- removes build_runner deps for testing, there is no need to use it for such a small package
- fixes a bug in discovery_test.dart that was probably landed due to inability to run tests