### PR TITLE
Recognize URIs starting with `dart-macro+`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 2.1.1-wip
+## 2.2.0-wip
 
 - Require Dart 3.2
+- Add support for `dart-macro+` scheme prefixes.
+  Recognizes these as belonging to the same package as their unprefixed URIs.
 
 ## 2.1.0
 

--- a/lib/src/package_config.dart
+++ b/lib/src/package_config.dart
@@ -166,9 +166,13 @@ abstract class PackageConfig {
 
   /// Provides the associated package for a specific [file] (or directory).
   ///
-  /// Returns a [Package] which contains the [file]'s path, if any.
+  /// If the [file] is a `package:` URI, it must be a *valid* `package:` URI,
+  /// and the package with that URI's package name is returned, if one exists.
+  ///
+  /// Otherwise returns a [Package] which contains the [file]'s path.
   /// That is, the [Package.root] directory is a parent directory
-  /// of the [file]'s location.
+  /// of the [file]'s location, based on the root URI being a prefix of this
+  /// [file] URI.
   ///
   /// Returns `null` if the file does not belong to any package.
   Package? packageOf(Uri file);
@@ -190,7 +194,7 @@ abstract class PackageConfig {
   /// [Package.packageUriRoot] of the corresponding package.
   Uri? resolve(Uri packageUri);
 
-  /// The package URI which resolves to [nonPackageUri].
+  /// The package URI which resolves to [nonPackageUri], if any.
   ///
   /// The [nonPackageUri] must not have any query or fragment part,
   /// and it must not have `package` as scheme.

--- a/lib/src/packages_file.dart
+++ b/lib/src/packages_file.dart
@@ -107,6 +107,13 @@ PackageConfig parse(
           'Package URI as location for package', source, separatorIndex + 1));
       continue;
     }
+    if (packageLocation.scheme.startsWith(dartMacroSchemePrefix)) {
+      onError(PackageConfigFormatException(
+          'Macro-generated URI as location for package',
+          source,
+          separatorIndex + 1));
+      continue;
+    }
     var path = packageLocation.path;
     if (!path.endsWith('/')) {
       path += '/';
@@ -120,6 +127,8 @@ PackageConfig parse(
     var rootUri = packageLocation;
     if (path.endsWith('/lib/')) {
       // Assume default Pub package layout. Include package itself in root.
+      // TODO(lrn): Stop doing this. Expect the package file to add a root
+      // if it wants a root.
       rootUri =
           packageLocation.replace(path: path.substring(0, path.length - 4));
     }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -40,14 +40,39 @@ int checkPackageName(String string) {
   return -1;
 }
 
+/// Dart macro generated augmentation file scheme for a package library.
+const dartMacroSchemePrefix = 'dart-macro+';
+
+/// Dart macro generated augmentation file scheme for a package library.
+const dartMacroPackageScheme = 'dart-macro+package';
+
+/// Dart macro generated augmentation file scheme for a file library.
+const dartMacroFileScheme = 'dart-macro+file';
+
+Map<String, String> _macroSchemeTranslation = {
+  dartMacroPackageScheme: 'package',
+  dartMacroFileScheme: 'file',
+};
+
+/// Convert a `dart-macro+` scheme to the underlying scheme.
+String schemeFromMacroScheme(String macroScheme) {
+  assert(macroScheme.startsWith(dartMacroSchemePrefix));
+  return _macroSchemeTranslation[macroScheme] ??=
+      macroScheme.substring(dartMacroSchemePrefix.length);
+}
+
 /// Validate that a [Uri] is a valid `package:` URI.
 ///
 /// Used to validate user input.
 ///
 /// Returns the package name extracted from the package URI,
 /// which is the path segment between `package:` and the first `/`.
-String checkValidPackageUri(Uri packageUri, String name) {
-  if (packageUri.scheme != 'package') {
+///
+/// If [allowMacro] is `true`, the scheme may also be `dart-macro+package`.
+String checkValidPackageUri(Uri packageUri, String name,
+    {bool allowMacro = false}) {
+  if (!packageUri.isScheme('package') &&
+      !(allowMacro && packageUri.isScheme(dartMacroPackageScheme))) {
     throw PackageConfigArgumentError(packageUri, name, 'Not a package: URI');
   }
   if (packageUri.hasAuthority) {
@@ -81,7 +106,7 @@ String checkValidPackageUri(Uri packageUri, String name) {
   if (badIndex >= 0) {
     if (packageName.isEmpty) {
       throw PackageConfigArgumentError(
-          packageUri, name, 'Package names mus be non-empty');
+          packageUri, name, 'Package names must be non-empty');
     }
     if (badIndex == packageName.length) {
       throw PackageConfigArgumentError(packageUri, name,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: package_config
-version: 2.1.1-wip
+version: 2.2.0-wip
 description: Support for reading and writing Dart Package Configuration files.
 repository: https://github.com/dart-lang/package_config
 

--- a/test/package_config_impl_test.dart
+++ b/test/package_config_impl_test.dart
@@ -183,6 +183,63 @@ void main() {
       'extra': 'data',
     });
   });
+
+  group('macro-generated', () {
+    const macroPrefix = 'dart-macro+';
+    var config = PackageConfig([
+      Package('foo', Uri.parse('file:///pkg/foo/'),
+          packageUriRoot: Uri.parse('file:///pkg/foo/lib/'),
+          languageVersion: LanguageVersion(3, 6)),
+      Package('bar', Uri.parse('file:///pkg/bar/'),
+          packageUriRoot: Uri.parse('file:///pkg/bar/lib/')),
+    ]);
+    test('package URI', () {
+      var uri = Uri.parse('${macroPrefix}package:foo/bar.dart');
+      // The macro-package-URI belongs to the package
+      // of the underlying `package:` URI.
+      var packageOf = config.packageOf(uri);
+      expect(packageOf, isNotNull);
+      expect(packageOf!.name, 'foo');
+
+      // The URI is not a package URI.
+      expect(() => config.resolve(uri), throwsArgumentError);
+
+      // And it has no corresponding package URI.
+      var toPackageUri = config.toPackageUri(uri);
+      expect(toPackageUri, null);
+    });
+
+    test('non-package URI outside lib/', () {
+      var uri = Uri.parse('${macroPrefix}file:///pkg/foo/tool/tool.dart');
+
+      var packageOf = config.packageOf(uri);
+      expect(packageOf, isNotNull);
+      expect(packageOf!.name, 'foo');
+
+      // The URI is not a package URI.
+      expect(() => config.resolve(uri), throwsArgumentError);
+
+      // And it has no corresponding package URI.
+      var toPackageUri = config.toPackageUri(uri);
+      expect(toPackageUri, null);
+    });
+
+    test('non-package URI inside lib/', () {
+      var uri = Uri.parse('${macroPrefix}file:///pkg/foo/lib/file.dart');
+
+      var packageOf = config.packageOf(uri);
+      expect(packageOf, isNotNull);
+      expect(packageOf!.name, 'foo');
+
+      // The URI is not a package URI.
+      expect(() => config.resolve(uri), throwsArgumentError);
+
+      // And it has no corresponding package URI, even if it
+      // "belongs" inside `lib/`.
+      var toPackageUri = config.toPackageUri(uri);
+      expect(toPackageUri, null);
+    });
+  });
 }
 
 final Matcher throwsPackageConfigError = throwsA(isA<PackageConfigError>());


### PR DESCRIPTION
Recognize URIs starting with dart-macro+
Such URIs belong to the same package as the the rest of the URI would, but are not `package:` URIs, and do not have a corresponding `package:` URI.
In this way, they behave like files inside the package, but outside of `lib/`, even if they are `dart-macro+package:` URIs.
